### PR TITLE
Parse Mode Setting for KeyBoard

### DIFF
--- a/src/Extensions/Keyboard.php
+++ b/src/Extensions/Keyboard.php
@@ -12,6 +12,7 @@ class Keyboard
     const TYPE_KEYBOARD = 'keyboard';
     const TYPE_INLINE = 'inline_keyboard';
 
+    protected $parseMode = 'Markdown';
     protected $oneTimeKeyboard = false;
     protected $resizeKeyboard = false;
 
@@ -61,6 +62,17 @@ class Keyboard
     }
 
     /**
+     * @param $mode
+     * @return $this
+     */
+    public function conParseMode($mode = 'Markdown')
+    {
+        $this->parseMode = $mode;
+
+        return $this;
+    }
+
+    /**
      * @param bool $active
      * @return $this
      */
@@ -89,6 +101,7 @@ class Keyboard
     public function toArray()
     {
         return [
+            'parse_mode' => $this->parseMode,
             'reply_markup' => json_encode(Collection::make([
                 $this->type => $this->rows,
                 'one_time_keyboard' => $this->oneTimeKeyboard,


### PR DESCRIPTION
Usage : 

```
$keyboard = Keyboard::create(Keyboard::TYPE_KEYBOARD)->oneTimeKeyboard()->conParseMode('Markdown')
            ->addRow(KeyboardButton::create('☹️')->callbackData('1'))
            ->addRow(KeyboardButton::create('🙁')->callbackData('2'))
            ->addRow(KeyboardButton::create('😐')->callbackData('3'))
            ->addRow(KeyboardButton::create('🙂')->callbackData('4'))
            ->addRow(KeyboardButton::create('😊')->callbackData('5'))
            ->toArray();
```